### PR TITLE
retriever cache validation warning

### DIFF
--- a/pyterrier_caching/retriever_cache.py
+++ b/pyterrier_caching/retriever_cache.py
@@ -57,6 +57,7 @@ class DbmRetrieverCache(pta.Artifact, pt.Transformer):
             pta.validate.columns(inp, includes=on)
         else:
             on = list(inp.columns)
+            pta.validate.query_frame(inp, warn=True)
         on = tuple(sorted(on))
 
         self._ensure_built(on)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 python-terrier>=0.11.0
-pyterrier-alpha>=0.11.0
+pyterrier-alpha>=0.14.0
 lz4
 numpy<2.0.0
 npids>=0.0.7


### PR DESCRIPTION
show validation warning if retriever cache is passed a result frame #20 and the cache keys are inferred